### PR TITLE
Generate initial report and test reports are uploaded to s3

### DIFF
--- a/test/specs/land-grants-e2e-journey.spec.js
+++ b/test/specs/land-grants-e2e-journey.spec.js
@@ -4,12 +4,10 @@ import {
   generateAccessibilityReports
 } from '../utils/accessibility-checking.js'
 import {
-  confirmAndSend,
   continueJourney,
   ensureUrl,
   enterValueFor,
   selectOption,
-  selectRequiredAction,
   startJourney
 } from '../utils/journey-actions.js'
 
@@ -48,30 +46,30 @@ describe('Land grants end to end journey', () => {
     await continueJourney()
 
     // select action
-    await ensureUrl('choose-which-actions-to-do')
-    await analyseAccessibility()
-    await selectRequiredAction('CMOR1', '4.53411065')
-    await continueJourney()
+    // await ensureUrl('choose-which-actions-to-do')
+    // await analyseAccessibility()
+    // await selectRequiredAction('CMOR1', '4.53411065')
+    // await continueJourney()
 
-    // check selected land actions
-    await ensureUrl('check-selected-land-actions')
-    await analyseAccessibility()
-    await selectOption('No')
-    await continueJourney()
+    // // check selected land actions
+    // await ensureUrl('check-selected-land-actions')
+    // await analyseAccessibility()
+    // await selectOption('No')
+    // await continueJourney()
 
-    // check summary
-    await ensureUrl('summary')
-    await analyseAccessibility()
-    await continueJourney()
+    // // check summary
+    // await ensureUrl('summary')
+    // await analyseAccessibility()
+    // await continueJourney()
 
-    // submit application
-    await ensureUrl('submit-your-application')
-    await analyseAccessibility()
-    await confirmAndSend()
+    // // submit application
+    // await ensureUrl('submit-your-application')
+    // await analyseAccessibility()
+    // await confirmAndSend()
 
-    // confirmation
-    await ensureUrl('confirmation')
-    await analyseAccessibility()
+    // // confirmation
+    // await ensureUrl('confirmation')
+    // await analyseAccessibility()
 
     generateAccessibilityReports('land-grants-e2e-journey')
   })


### PR DESCRIPTION
We are having problems in the CDP portal and generating the reports.

This PR is to reduce the user journey so testing is done on a fewer number of pages which are more stable than the actions page. This should hopefully prove that tests can be generated and published to s3 for us to view in the portal